### PR TITLE
In reference to feature request for Covenant. #101

### DIFF
--- a/resources/language/English (US)/strings.po
+++ b/resources/language/English (US)/strings.po
@@ -567,6 +567,10 @@ msgctxt "#32360"
 msgid "Providers Language"
 msgstr ""
 
+msgctxt "#32363"
+msgid "HEVC"
+msgstr ""
+
 msgctxt "#32401"
 msgid "No stream available"
 msgstr ""

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -567,6 +567,10 @@ msgctxt "#32360"
 msgid "Providers Language"
 msgstr ""
 
+msgctxt "#32363"
+msgid "HEVC"
+msgstr ""
+
 msgctxt "#32401"
 msgid "No stream available"
 msgstr ""

--- a/resources/lib/modules/sources.py
+++ b/resources/lib/modules/sources.py
@@ -572,7 +572,7 @@ class sources:
             if 'checkquality' in i and i['checkquality'] == True: 
                 if not i['source'].lower() in self.hosthqDict and i['quality'] not in ['SD', 'SCR', 'CAM']: i.update({'quality': 'SD'})
 
-        local = [i for i in self.sources if 'local' in i and i['local'] == True]
+        local = [i for i in self.sources if 'local' in i and i['local'] == True] 
         for i in local: i.update({'language': self._getPrimaryLang() or 'en'})
         self.sources = [i for i in self.sources if not i in local]
 

--- a/resources/lib/modules/sources.py
+++ b/resources/lib/modules/sources.py
@@ -561,6 +561,8 @@ class sources:
 
         captcha = control.setting('hosts.captcha')
 
+    HEVC = control.setting('HEVC')
+        
         random.shuffle(self.sources)
 
         if provider == 'true':
@@ -663,6 +665,13 @@ class sources:
 
             self.sources[i]['label'] = label.upper()
 
+    if HEVC == 'true':                                                               
+		filter += [i for i in self.sources if 'HEVC' not in ''.join(i['label'])] 
+        
+    if not HEVC == 'true':
+		filter += [i for i in self.sources]
+    self.sources = filter
+    
         return self.sources
 
 

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -25,6 +25,7 @@
         <setting type="lsep" label="32338" />
         <setting id="hosts.quality" type="enum" label="32339" values="4K|1440p|1080p|720p|480p" default="0" />
         <setting id="autoplay.sd" type="bool" label="32340" default="false" />
+        <setting id="HEVC" type="bool" label="32363" default="true" />
         <setting id="hosts.captcha" type="bool" label="32341" default="true" />
         <setting id="hosts.sort.provider" type="bool" label="32342" default="false" />
         <setting type="lsep" label="32343" />


### PR DESCRIPTION
This is a working Covenant that has the HEVC filter option in the settings, to allow users to choose whether or not to have HEVC files show up in the the sources search.
This will allow older hardware users to make full use of the auto play function and sifting through streams to find a playable stream, especially if they subscribe to a service like Real-Debrid.