### PR TITLE
Update sources.py for HEVC filter

### DIFF
--- a/resources/lib/modules/sources.py
+++ b/resources/lib/modules/sources.py
@@ -560,9 +560,9 @@ class sources:
         if quality == '': quality = '0'
 
         captcha = control.setting('hosts.captcha')
-
+	
     HEVC = control.setting('HEVC')
-        
+		
         random.shuffle(self.sources)
 
         if provider == 'true':
@@ -665,12 +665,12 @@ class sources:
 
             self.sources[i]['label'] = label.upper()
 
-    if HEVC == 'true':                                                               
+	if HEVC == 'true':                                                               
 		filter += [i for i in self.sources if 'HEVC' not in ''.join(i['label'])] 
         
-    if not HEVC == 'true':
+	if not HEVC == 'true':
 		filter += [i for i in self.sources]
-    self.sources = filter
+	self.sources = filter
     
         return self.sources
 


### PR DESCRIPTION
@Colossal1 

 I have tried to fix the indent errors that somebody has reported on my HEVC filter.
I have reviewed and fixed the code but there is a big BUT that needs addressing before this can be pulled.
whenever I save changes  to  the file, code lines 668,669,671,672,673 seem to show as tabbing indents to 8 spaces in the file and if you enter edit mode again the lines revert back to a tab of 4 spaces.
I have tried sveral times to correct this and without a tab indent of 4 spaces the filter will not work as intended and I will also upload a working copy of the sources file for you to look at should none of this makes much sense. 
[sources.zip](https://github.com/Colossal1/plugin.video.covenant/files/1272856/sources.zip)
