### PR TITLE
Update strings.po

### DIFF
--- a/resources/language/Greek/strings.po
+++ b/resources/language/Greek/strings.po
@@ -501,7 +501,7 @@ msgstr "Όταν αρχίζει η αναπαραγωγή..."
 
 msgctxt "#32344"
 msgid "Resume Playback"
-msgstr "Επανεκκίνηση αναπαραγωγής"
+msgstr "Συνέχεια αναπαραγωγής"
 
 msgctxt "#32345"
 msgid "Providers"
@@ -605,11 +605,11 @@ msgstr "Εκκίνηση από την αρχή"
 
 msgctxt "#32502"
 msgid "Resume from %s"
-msgstr "Επανεκκίνηση από %s"
+msgstr "Συνέχεια από %s"
 
 msgctxt "#32503"
 msgid "Resume"
-msgstr "Επανεκκίνηση"
+msgstr "Συνέχεια"
 
 msgctxt "#32511"
 msgid "An account already exists."


### PR DESCRIPTION
Changes at lines 504, 608 and 612: "Resume" from "Επανεκκίνηση" to "Συνέχεια". This has been incorrectly translated all the way from the beginning since exodus.