### PR TITLE
Update settings.xml

### DIFF
--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -39,15 +39,17 @@
     <category label="32345">
         <setting label="English" type="lsep" />
         <setting type="sep" />
-        <setting id="provider.2dll" type="bool" label="2DLL" default="true" />
         <setting id="provider.123hulu" type="bool" label="123HULU" default="true" />
         <setting id="provider.123netflix" type="bool" label="123NETFLIX" default="true" />
+        <setting id="provider.2dll" type="bool" label="2DLL" default="true" />
         <setting id="provider.afdah" type="bool" label="AFDAH" default="true" />
         <setting id="provider.allrls" type="bool" label="ALLRLS" default="true" />
+        <setting id="provider.allucen" type="bool" label="ALLUC_EN" default="true" />
         <setting id="provider.animeultima" type="bool" label="ANIMEULTIMA" default="true" />
         <setting id="provider.bestmoviez" type="bool" label="BESTMOVIEZ" default="true" />
-        <setting id="provider.ddlvalley" type="bool" label="DDLVALLEY" default="true" />
+        <setting id="provider.cmovies" type="bool" label="CMOVIES" default="true" />
         <setting id="provider.ddls" type="bool" label="DDLS" default="true" />
+        <setting id="provider.ddlvalley" type="bool" label="DDLVALLEY" default="true" />
         <setting id="provider.directdl" type="bool" label="DIRECTDL" default="true" />
         <setting id="provider.divxcrawler" type="bool" label="DIVXCRAWLER" default="true" />
         <setting id="provider.dizigold" type="bool" label="DIZIGOLD" default="true" />
@@ -59,6 +61,7 @@
         <setting id="provider.hevcfilm" type="bool" label="HEVCFILM" default="true" />
         <setting id="provider.icefilms" type="bool" label="ICEFILMS" default="true" />
         <setting id="provider.icefilmsis" type="bool" label="ICEFILMSIS" default="true" />
+        <setting id="provider.imdark" type="bool" label="IMDARK" default="true" />
         <setting id="provider.kingmovies" type="bool" label="KINGMOVIES" default="true" />
         <setting id="provider.library" type="bool" label="LIBRARY" default="true" />
         <setting id="provider.miradetodo" type="bool" label="MIRADETODO" default="true" />
@@ -66,10 +69,12 @@
         <setting id="provider.movie4korg" type="bool" label="MOVIE4KORG" default="true" />
         <setting id="provider.movie4uch" type="bool" label="MOVIE4UCH" default="true" />
         <setting id="provider.moviesgold" type="bool" label="MOVIESGOLD" default="true" />
+        <setting id="provider.moviesplanet" type="bool" label="MOVIESPLANET" default="true" />
         <setting id="provider.mywatchseries" type="bool" label="MYWATCHSERIES" default="true" />
         <setting id="provider.mzmovies" type="bool" label="MZMOVIES" default="true" />
         <setting id="provider.onlinedizi" type="bool" label="ONLINEDIZI" default="true" />
         <setting id="provider.openloadmovies" type="bool" label="OPENLOADMOVIES" default="true" />
+        <setting id="provider.ororo" type="bool" label="ORORO" default="true" />
         <setting id="provider.phazeddl" type="bool" label="PHAZEDLL" default="true" />
         <setting id="provider.plocker" type="bool" label="PLOCKER" default="true" />
         <setting id="provider.popcorn" type="bool" label="POPCORN" default="true" />
@@ -85,6 +90,7 @@
         <setting id="provider.seriesfree" type="bool" label="SERIESFREE" default="true" />
         <setting id="provider.sezonlukdizi" type="bool" label="SEZONLUKDIZI" default="true" />
         <setting id="provider.solarmovie" type="bool" label="SOLARMOVIE" default="true" />
+        <setting id="provider.streamlord" type="bool" label="STREAMLORD" default="true" />
         <setting id="provider.tvbox" type="bool" label="TVBOX" default="true" />
         <setting id="provider.tvrelease" type="bool" label="TVRELEASE" default="true" />
         <setting id="provider.videoscraper" type="bool" label="VIDEOSCRAPER" default="true" />
@@ -93,18 +99,13 @@
         <setting id="provider.watchfree" type="bool" label="WATCHFREE" default="true" />
         <setting id="provider.watchseries" type="bool" label="WATCHSERIES" default="true" />
         <setting id="provider.wrzcraft" type="bool" label="WRZCRAFT" default="true" />
-<<<<<<< HEAD
-        <setting id="provider.videoscraper" type="bool" label="VIDEOSCRAPER" default="true" />
-        <setting id="provider.vodly" type="bool" label="VODLY" default="true" />
         <setting id="provider.xmovies" type="bool" label="XMOVIES" default="true" />
-=======
         <setting id="provider.xwatchseries" type="bool" label="XWATCHSERIES" default="true" />
->>>>>>> Colossal1/master
         <setting id="provider.ymovies" type="bool" label="YMOVIES" default="true" />
         <setting label="Italian" type="lsep" />
-        <setting id="provider.allucit" type="bool" label="ALLUC" default="true" />
+        <setting id="provider.allucit" type="bool" label="ALLUC_IT" default="true" />
         <setting label="German" type="lsep" />
-        <setting id="provider.allucde" type="bool" label="ALLUC" default="true" />
+        <setting id="provider.allucde" type="bool" label="ALLUC_DE" default="true" />
         <setting id="provider.animebase" type="bool" label="ANIMEBASE" default="true" />
         <setting id="provider.animeloads" type="bool" label="ANIMELOADS" default="true" />
         <setting id="provider.bs" type="bool" label="BS" default="true" />
@@ -142,7 +143,7 @@
         <setting id="provider.video4k" type="bool" label="VIDEO4K" default="true" />
         <setting id="provider.view4u" type="bool" label="VIEW4U" default="true" />
         <setting label="French" type="lsep" />
-        <setting id="provider.allucfr" type="bool" label="ALLUC" default="true" />
+        <setting id="provider.allucfr" type="bool" label="ALLUC_FR" default="true" />
         <setting id="provider.cinemay" type="bool" label="CINEMAY" default="true" />
         <setting id="provider.dpstreaming" type="bool" label="DPSTREAMING" default="true" />
         <setting id="provider.filmenstreaminghd" type="bool" label="FILMENSTREAMINGHD" default="true" />
@@ -152,7 +153,7 @@
         <setting id="provider.streamay" type="bool" label="STREAMAY" default="true" />
         <setting id="provider.streamingseries" type="bool" label="STREAMINGSERIES" default="true" />
         <setting label="Polish" type="lsep" />
-        <setting id="provider.allucpl" type="bool" label="ALLUC" default="true" />
+        <setting id="provider.allucpl" type="bool" label="ALLUC_PL" default="true" />
         <setting id="provider.alltube" type="bool" label="ALLTUBE" default="true" />
         <setting id="provider.filmyto" type="bool" label="FILMYTO" default="true" />
         <setting id="provider.cdax" type="bool" label="CDAX" default="true" />
@@ -187,10 +188,10 @@
         <setting id="provider.seriespapaya" type="bool" label="SERIESPAPAYA" default="true" />
         <setting label="Greek" type="lsep" />
         <setting id="provider.gamatotv" type="bool" label="GAMATO" default="true" />
+        <setting id="provider.liomenoi" type="bool" label="LIOMENOI" default="true" />
         <setting id="provider.tainiomania" type="bool" label="TAINIOMANIA" default="true" />
         <setting id="provider.tainiesonline" type="bool" label="TAINIESONLINE" default="true" />
         <setting id="provider.xrysoi" type="bool" label="XRYSOI" default="true" />
-        <setting id="provider.liomenoi" type="bool" label="LIOMENOI" default="true" />
     </category>
     <category label="32346">
         <setting type="lsep" label="FANART.TV" />


### PR DESCRIPTION
Some providers do not have on/off setting on PROVIDERS tab.
I understand that most of those providers (alluc, moviesplanet, ororo, streamlord) require an account to work, which if you insert they get enabled, however imo one should still be able to (easily) disable them, in case eg they break or are slow.
There are also some normal providers (that don't need account to work - imdark, cmovies) that don't have a setting.
Finally I did some sorting and removed some lines that I guess someone left as a reminder or something?